### PR TITLE
Provide ability to disable ssl verification

### DIFF
--- a/lib/torpedo.rb
+++ b/lib/torpedo.rb
@@ -71,6 +71,10 @@ SECURITY_GROUPS = configs['security_groups']
 include Test::Unit::UI::Console::OutputLevel
 OUTPUT_LEVEL = Kernel.const_get(configs['output_level'].upcase) || NORMAL
 
+# ssl verification
+
+DISABLE_SSL_CHECK = configs['disable_ssl_check']
+
 FOG_VERSION=configs['fog_version']
 
 TORPEDO_TEST_SUITE = Test::Unit::TestSuite.new("Torpedo")

--- a/lib/torpedo.rb
+++ b/lib/torpedo.rb
@@ -64,7 +64,7 @@ STACK_CREATE_TIMEOUT = (orchestration_opts['stack_create_timeout'] || 120).to_i
 CLEAN_UP_STACKS = orchestration_opts.fetch('cleanup', true)
 
 # compute opts
-AVAILABILITY_ZONE = configs['availability_zone']
+AVAILABILITY_ZONE = ENV['OS_AVAILABILITY_ZONE'] || configs['availability_zone']
 SECURITY_GROUPS = configs['security_groups']
 
 # output verbosity

--- a/lib/torpedo/compute/helper.rb
+++ b/lib/torpedo/compute/helper.rb
@@ -17,6 +17,10 @@ module Torpedo
           ENV['EXCON_DEBUG'] = 'true'
         end
 
+        if DISABLE_SSL_CHECK
+          Excon.defaults[:ssl_verify_peer] = false
+        end
+
         auth_url = ENV['NOVA_URL'] || ENV['OS_AUTH_URL']
         api_key = ENV['NOVA_API_KEY'] || ENV['OS_PASSWORD']
         username = ENV['NOVA_USERNAME'] || ENV['OS_USERNAME']

--- a/lib/torpedo/metering/helper.rb
+++ b/lib/torpedo/metering/helper.rb
@@ -17,6 +17,10 @@ module Torpedo
           ENV['EXCON_DEBUG'] = 'true'
         end
 
+        if DISABLE_SSL_CHECK
+          Excon.defaults[:ssl_verify_peer] = false
+        end
+
         auth_url = ENV['OS_AUTH_URL']
         api_key = ENV['OS_PASSWORD']
         username = ENV['OS_USERNAME']

--- a/lib/torpedo/orchestration/helper.rb
+++ b/lib/torpedo/orchestration/helper.rb
@@ -17,6 +17,10 @@ module Torpedo
           ENV['EXCON_DEBUG'] = 'true'
         end
 
+        if DISABLE_SSL_CHECK
+          Excon.defaults[:ssl_verify_peer] = false
+        end
+
         auth_url = ENV['OS_AUTH_URL']
         api_key = ENV['OS_PASSWORD']
         username = ENV['OS_USERNAME']

--- a/lib/torpedo/volume/helper.rb
+++ b/lib/torpedo/volume/helper.rb
@@ -17,6 +17,10 @@ module Torpedo
           ENV['EXCON_DEBUG'] = 'true'
         end
 
+        if DISABLE_SSL_CHECK
+          Excon.defaults[:ssl_verify_peer] = false
+        end
+
         auth_url = ENV['OS_AUTH_URL']
         api_key = ENV['OS_PASSWORD']
         username = ENV['OS_USERNAME']


### PR DESCRIPTION
Sometimes we do not have luxury of valid ssl certificates and should use self-signed for temporary testing purposes.

This PR enables the functionality to disable ssl verification in torpedo run